### PR TITLE
feat: add from-useq convenience function

### DIFF
--- a/src/ome_writers/__init__.py
+++ b/src/ome_writers/__init__.py
@@ -10,9 +10,9 @@ except PackageNotFoundError:  # pragma: no cover
     __version__ = "uninstalled"
 
 from ._auto import BackendName, create_stream
-from ._dimensions import Dimension, DimensionLabel
+from ._dimensions import Dimension, DimensionLabel, UnitTuple
 from ._stream_base import OMEStream
-from ._util import fake_data_for_sizes
+from ._util import dims_from_useq, fake_data_for_sizes
 from .backends._acquire_zarr import AcquireZarrStream
 from .backends._tensorstore import TensorStoreZarrStream
 from .backends._tifffile import TifffileStream
@@ -25,7 +25,9 @@ __all__ = [
     "OMEStream",
     "TensorStoreZarrStream",
     "TifffileStream",
+    "UnitTuple",
     "__version__",
     "create_stream",
+    "dims_from_useq",
     "fake_data_for_sizes",
 ]

--- a/src/ome_writers/_dimensions.py
+++ b/src/ome_writers/_dimensions.py
@@ -17,13 +17,16 @@ OME_DIM_TYPE = {"y": "space", "x": "space", "z": "space", "t": "time", "c": "cha
 OME_UNIT = {"um": "micrometer", "ml": "milliliter", "s": "second", None: "unknown"}
 
 
+# Recognized dimension labels
 DimensionLabel: TypeAlias = Literal["x", "y", "z", "t", "c", "p", "other"]
+# UnitTuple is a tuple of (scale, unit); e.g. (1, "s")
+UnitTuple: TypeAlias = tuple[float, str]
 
 
 class Dimension(NamedTuple):
     label: DimensionLabel
     size: int
-    unit: tuple[float, str] | None = None
+    unit: UnitTuple | None = None
     # None or 0 indicates no constraint.
     # -1 indicates that the chunk size should equal the full extent of the domain.
     chunk_size: int | None = None


### PR DESCRIPTION
I expect a common conversion when using this library (esp with `pymmcore-plus`) will be to convert a `useq.MDASequence` into a `Sequence[Dimension]`.

This adds a `ome_writers.dims_from_useq` convenience function that can be used as follows:

```python
from ome_writers import create_stream, dims_from_useq

width, height = however_you_get_expected_image_dimensions()
dims = dims_from_useq(seq, image_width=width, image_height=height)

with create_stream(
    path=...,
    dimensions=dims,
    dtype=np.uint16,
    backend=...,
) as stream:
    for frame in whatever_generates_your_data():
        stream.append(frame)
```

cc @jeskesen 