### PR TITLE
refactor: unfreeze AcquisitionSettings

### DIFF
--- a/src/ome_writers/_schema.py
+++ b/src/ome_writers/_schema.py
@@ -34,7 +34,7 @@ StandardAxisKey: TypeAlias = Literal["x", "y", "z", "c", "t", "p"]
 
 
 class _BaseModel(BaseModel):
-    """Base model with frozen config."""
+    """Base model with common configuration."""
 
     model_config = ConfigDict(
         validate_default=True,
@@ -401,13 +401,7 @@ class AcquisitionSettings(_BaseModel):
 
     Pass this object to [ome_writers.create_stream][] to create a data stream
     for writing acquisition data.
-
-    !!! note
-        This is a frozen model.  Use `.model_copy(update={...})` to create modified
-        copies.
     """
-
-    model_config = ConfigDict(frozen=True, validate_default=True)
 
     root_path: Annotated[str, BeforeValidator(str)] = Field(
         description="Root output path for the acquisition data.  This may be a "

--- a/src/ome_writers/_stream.py
+++ b/src/ome_writers/_stream.py
@@ -209,6 +209,10 @@ def create_stream(settings: AcquisitionSettings) -> OMEStream:
     ...     for i in range(20):  # 10 timepoints x 2 channels
     ...         stream.append(np.zeros((512, 512), dtype=np.uint16))
     """
+    # rather than making AcquisitionSettings a frozen model,
+    # copy the settings once here.  The point is that no modifications made
+    # to the settings after this call will be reflected in the stream.
+    settings = settings.model_copy(deep=True)
 
     backend: ArrayBackend = _create_backend(settings)
     router = FrameRouter(settings)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -335,7 +335,8 @@ def test_tiff_backend_format(tiff_backend: str) -> None:
     )
     assert settings.format == "tiff"
 
-    settings2 = settings.model_copy(update={"backend": "acquire-zarr"})
+    settings2 = settings.model_copy(deep=True)
+    settings2.backend = "acquire-zarr"
     assert settings2.format == "zarr"
 
 

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -60,11 +60,7 @@ from rich.console import Console
 from rich.progress import track
 from rich.table import Table
 
-from ome_writers import (
-    AcquisitionSettings,
-    _schema,
-    create_stream,
-)
+from ome_writers import AcquisitionSettings, _schema, create_stream
 from ome_writers._stream import AVAILABLE_BACKENDS, get_format_for_backend
 
 if TYPE_CHECKING:
@@ -148,8 +144,9 @@ def run_benchmark(
     iterations: int,
 ) -> ResultsDict:
     """Run benchmark for a single backend with multiple iterations."""
-    root = f"test_{backend}.ome.{get_format_for_backend(backend)}"
-    settings = settings.model_copy(update={"backend": backend, "root_path": root})
+    settings = settings.model_copy(deep=True)
+    settings.root_path = f"test_{backend}.ome.{get_format_for_backend(backend)}"
+    settings.backend = backend  # type: ignore
 
     # Warmup runs
     if warmups > 0:

--- a/tools/profiler.py
+++ b/tools/profiler.py
@@ -194,8 +194,8 @@ def main(
             root_path="tmp", dimensions=dims, dtype=dtype, compression=compression
         )
 
-    root = f"test_{backend}.ome.{get_format_for_backend(backend)}"
-    settings = settings.model_copy(update={"backend": backend, "root_path": root})
+    settings.root_path = f"test_{backend}.ome.{get_format_for_backend(backend)}"
+    settings.backend = backend  # type: ignore
 
     console.print(f"\n[bold]Profiling {backend}[/bold]")
     console.print(f"  Shape: {tuple(d.count for d in settings.dimensions)}")


### PR DESCRIPTION
this is a small PR that just removes `ConfigDict(frozen=True)` from `AcquisitionSettings`.  

Making objects that are passed around a lot immutable is "safe", and so I defaulted to it... but it's also annoying from a user-perspective that wants to progressively construct an object (mutating it) before using it.  Moreover, the primary tool that pydantic gives you is `model_copy(update={})`... but the values in the `update` dictionary don't go through validation... making that a potential footgun for models that make any use of validator casting (as we do).

In this case, the only place we really need the object to be immutable is *after* calling `create_stream`, and so this PR just makes a full deepcopy of the object right inside of `create_stream` instead.  Changes some test patterns accordingly