### PR TITLE
test: add test to ensure retention of full streaming support in acquire-zarr

### DIFF
--- a/tests/test_acquire_zarr_streaming.py
+++ b/tests/test_acquire_zarr_streaming.py
@@ -50,14 +50,14 @@ def test_acquire_zarr_full_streaming_support(tmp_path: Path) -> None:
 
 def _zarr_array_to_numpy(path: str) -> np.ndarray:
     try:
-        import zarr
-
-        return np.asarray(zarr.open_array(path))
-    except ImportError:
         import tensorstore as ts
 
         ts_array = ts.open(
-            {"driver": "zarr", "kvstore": {"driver": "file", "path": path}},
+            {"driver": "zarr3", "kvstore": {"driver": "file", "path": path}},
             open=True,
         ).result()
         return np.asarray(ts_array.read().result())
+    except ImportError:
+        import zarr
+
+        return np.asarray(zarr.open_array(path))


### PR DESCRIPTION
In https://github.com/pymmcore-plus/ome-writers/issues/41#issuecomment-3812027247 @aliddell raised the very good point about implicit shape assumptions for the buffer being passed to `stream.append()`.    In https://github.com/pymmcore-plus/ome-writers/issues/41#issuecomment-3812266310 I mentioned that it's sort of back-end dependent... and that currently we do support the full semantics of `stream.append()` supported by acquire-zarr (the buffer is just passed through as is)

That's a very cool, non-trivial thing that acquire-zarr does... so we want to make sure not to accidentally lose that feature.  This PR just adds a backend specific test for that feature