### PR TITLE
ci: Disable docs build on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.repository == 'pymmcore-plus/ome-writers' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Docs build fails on repo forks, this PR adds that the workflow should only run on `pymmcore-plus/ome-writers`. Alternatively @tlambert03 may be able to adjust some GitHub settings, not sure if they require Enterprise-level account. It would be nice if only the docs build - and not all workflows, are disabled.