### PR TITLE
ci: only do benchmarks on our repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     needs: changes
     # skip on PRs that don't touch relevant files (CodSpeed partial runs
     # will fill in historical data for the missing benchmarks)
-    if: needs.changes.outputs.bench == 'true' || github.event_name != 'pull_request'
+    if: (needs.changes.outputs.bench == 'true' || github.event_name != 'pull_request') && (github.repository == 'pymmcore-plus/ome-writers')
     # using bare-metal runner for more consistent benchmark results
     # this has time limit
     runs-on: codspeed-macro


### PR DESCRIPTION
similar to #93 ... this only runs benchmarks (on codspeed macro runners) when running PRs in this org