### PR TITLE
Disable upload_coverage on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
           include-hidden-files: true
 
   upload_coverage:
-    if: always()
+    if: always() && github.repository == 'pymmcore-plus/ome-writers'
     needs: [test]
     uses: pyapp-kit/workflows/.github/workflows/upload-coverage.yml@v2
     secrets:


### PR DESCRIPTION
One more. Keeping `always()` allows coverage to get updated on `pymmcore-plus/ome-writers` even if tests fail.