### PR TITLE
fix: don't write empty MapAnnotations in Tiff metadata if we don't have extra frame metadata

### DIFF
--- a/src/ome_writers/_backends/_tifffile.py
+++ b/src/ome_writers/_backends/_tifffile.py
@@ -283,15 +283,15 @@ class TiffBackend(ArrayBackend):
                     extra_kwargs[key] = value
 
             # meta_with_idx = {**frame_metadata, "storage_index": index}
-            annotation = ome.MapAnnotation(value=ome.Map.model_validate(extra_kwargs))
-            map_annotations.append(annotation)
-            planes = images[position_index].pixels.planes
-            planes.append(
-                ome.Plane(
-                    **plane_kwargs,
-                    annotation_refs=[ome.AnnotationRef(id=annotation.id)],
+            annotation_refs: list[ome.AnnotationRef] = []
+            if extra_kwargs:
+                annotation = ome.MapAnnotation(
+                    value=ome.Map.model_validate(extra_kwargs)
                 )
-            )
+                map_annotations.append(annotation)
+                annotation_refs.append(ome.AnnotationRef(id=annotation.id))
+            planes = images[position_index].pixels.planes
+            planes.append(ome.Plane(**plane_kwargs, annotation_refs=annotation_refs))
             mirror.mark_dirty()
 
     def finalize(self) -> None:

--- a/tests/test_tiff_metadata.py
+++ b/tests/test_tiff_metadata.py
@@ -436,6 +436,42 @@ def test_frame_metadata_single_position(tmp_path: Path, tiff_backend: str) -> No
     assert planes[0].annotation_refs[0].id == map_annots[0].id
 
 
+def test_frame_metadata_plane_keys_only(tmp_path: Path, tiff_backend: str) -> None:
+    """Don't write empty map annotations if frame_metadata only contains plane keys."""
+    root = tmp_path / "plane_only.ome.tiff"
+    settings = AcquisitionSettings(
+        root_path=root,
+        dimensions=[
+            Dimension(name="t", count=2, type="time"),
+            Dimension(name="y", count=16, type="space"),
+            Dimension(name="x", count=16, type="space"),
+        ],
+        dtype="uint16",
+        format=tiff_backend,
+    )
+
+    with create_stream(settings) as stream:
+        for t in range(2):
+            frame = np.zeros((16, 16), dtype=np.uint16)
+            stream.append(
+                frame,
+                frame_metadata={"delta_t": t * 1.0, "exposure_time": 0.05},
+            )
+
+    ome_obj = from_tiff(str(root))
+    planes = ome_obj.images[0].pixels.planes
+    assert len(planes) == 2
+    assert planes[0].delta_t == 0.0
+    assert planes[1].delta_t == 1.0
+    assert planes[0].exposure_time == 0.05
+
+    # No extra keys beyond plane keys, so no annotations should exist
+    sa = ome_obj.structured_annotations
+    assert sa is None or len(sa.map_annotations) == 0
+    for plane in planes:
+        assert len(plane.annotation_refs) == 0
+
+
 def test_frame_metadata_multiposition(tmp_path: Path, tiff_backend: str) -> None:
     """Test frame_metadata is position-specific for multi-position."""
     root = tmp_path / "multipos.ome.tiff"


### PR DESCRIPTION
fixes #125