### PR TITLE
fix: use fov naming for plate positions with grid_plan

### DIFF
--- a/src/ome_writers/_useq.py
+++ b/src/ome_writers/_useq.py
@@ -448,14 +448,18 @@ def _pos_with_grid_point(
         x_coord = (pos.x or 0) + (gp.x or 0)
         y_coord = (pos.y or 0) + (gp.y or 0)
 
-    # When there is no row/col (e.g. RandomPoints), append an index to the
-    # name so each sub-position is unique
+    # Ensure each sub-position gets a unique name within its parent position.
     if gp.grid_row is None and gp.grid_col is None:
+        # No grid coordinates (e.g. RandomPoints) — append an index to the name
         if pos_idx is not None:
             suffix = f"p{pos_idx:04d}_g{gp_idx:04d}"
             name = f"{name}_{suffix}" if name else suffix
         else:
             name = f"{name}_g{gp_idx:04d}" if name else f"{gp_idx:04d}"
+    elif pos.plate_row is not None and pos.plate_col is not None:
+        # Plate positions with grid coordinates need unique names within each well,
+        # consistent with WellPlatePlan's fov naming convention
+        name = f"fov{gp_idx}"
 
     plate_row, plate_col = _plate_strs(pos)
     return Position(

--- a/tests/test_useq.py
+++ b/tests/test_useq.py
@@ -160,6 +160,30 @@ SEQ_CASES = [
         ],
         id="well_plate_with_points",
     ),
+    # Plate positions (plate_row/plate_col) combined with a global grid_plan
+    # Each stage position should produce fov0..fovN within its well (issue #131)
+    Case(
+        seq=useq.MDASequence(
+            axis_order="pgtc",
+            stage_positions=[
+                useq.Position(x=0, y=0, plate_row=0, plate_col=0),
+                useq.Position(x=10, y=10, plate_row=0, plate_col=1),
+                useq.Position(x=20, y=20, plate_row=1, plate_col=0),
+            ],
+            grid_plan=useq.GridRowsColumns(rows=1, columns=2),
+            channels=["DAPI"],
+        ),
+        expected_dim_names=["p", "c", "y", "x"],
+        expected_positions=[
+            ExpectedPosition("fov0", "A", "1", grid_row=0, grid_col=0),
+            ExpectedPosition("fov1", "A", "1", grid_row=0, grid_col=1),
+            ExpectedPosition("fov0", "A", "2", grid_row=0, grid_col=0),
+            ExpectedPosition("fov1", "A", "2", grid_row=0, grid_col=1),
+            ExpectedPosition("fov0", "B", "1", grid_row=0, grid_col=0),
+            ExpectedPosition("fov1", "B", "1", grid_row=0, grid_col=1),
+        ],
+        id="plate_positions_with_global_grid",
+    ),
     # MultiPhaseTimePlan - no single .interval attribute
     Case(
         seq=useq.MDASequence(


### PR DESCRIPTION
## Summary
- When stage_positions have `plate_row`/`plate_col` and are combined with a global `grid_plan`, each grid sub-position within a well now gets a unique name (`fov0`, `fov1`, ...) consistent with `WellPlatePlan`'s naming convention
- Previously all grid sub-positions shared the parent position's name, causing `Duplicate output key` errors in the zarr writer
- Added test case for this scenario in `test_useq_to_dims`

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)