### PR TITLE
fix: assign fov names for plate positions with grid_plan

### DIFF
--- a/src/ome_writers/_useq.py
+++ b/src/ome_writers/_useq.py
@@ -428,14 +428,52 @@ def _plate_strs(pos: useq.Position) -> tuple[str | None, str | None]:
     return None, None
 
 
+def _grid_position_name(
+    pos: useq.Position,
+    gp: useq.Position,
+    gp_idx: int,
+    pos_idx: int | None,
+    has_plate: bool,
+) -> str:
+    """Determine the name for a grid-expanded position.
+
+    Naming priority:
+    1. Explicit name from user (may be further suffixed for RandomPoints)
+    2. fov{grid_index} for plate positions (matches WellPlatePlan convention)
+    3. str(position_index) fallback
+
+    For RandomPoints (no grid_row/grid_col), an index suffix is appended
+    to ensure uniqueness since grid coordinates can't distinguish positions.
+    """
+    if pos.name:
+        name = pos.name
+    elif has_plate:
+        return f"fov{gp_idx}"
+    else:
+        # pos_idx is None when there's only one position (index 0)
+        name = str(pos_idx if pos_idx is not None else 0)
+
+    # RandomPoints have no grid_row/grid_col — append index for uniqueness
+    if gp.grid_row is None and gp.grid_col is None:
+        if pos_idx is not None:
+            suffix = f"p{pos_idx:04d}_g{gp_idx:04d}"
+            return f"{name}_{suffix}" if name else suffix
+        else:
+            return f"{name}_g{gp_idx:04d}" if name else f"{gp_idx:04d}"
+
+    return name
+
+
 def _pos_with_grid_point(
     name: str,
     pos: useq.Position,
     gp: useq.Position,
-    gp_idx: int = 0,
-    pos_idx: int | None = None,
 ) -> Position:
-    """Create a Position by combining a stage position with a grid point."""
+    """Create a Position by combining a stage position with a grid point.
+
+    Handles only coordinate merging — all naming logic lives in the caller
+    (_build_stage_positions_plan).
+    """
     # If we have an absolute grid plan, the grid point coordinates are used directly.
     # This results from a design flaw in useq where it's possible to combine
     # an absolute grid plan with (absolute) stage positions.  We will likely change
@@ -447,15 +485,6 @@ def _pos_with_grid_point(
         # relative grid points are offsets from the stage position
         x_coord = (pos.x or 0) + (gp.x or 0)
         y_coord = (pos.y or 0) + (gp.y or 0)
-
-    # When there is no row/col (e.g. RandomPoints), append an index to the
-    # name so each sub-position is unique
-    if gp.grid_row is None and gp.grid_col is None:
-        if pos_idx is not None:
-            suffix = f"p{pos_idx:04d}_g{gp_idx:04d}"
-            name = f"{name}_{suffix}" if name else suffix
-        else:
-            name = f"{name}_g{gp_idx:04d}" if name else f"{gp_idx:04d}"
 
     plate_row, plate_col = _plate_strs(pos)
     return Position(
@@ -493,8 +522,10 @@ def _build_stage_positions_plan(seq: useq.MDASequence) -> list[Position]:
     if grid_first and global_grid:
         # Grid-first: outer loop is grid points, inner loop is positions
         return [
-            _pos_with_grid_point(pos.name or str(p_idx), pos, gp)
-            for gp in global_grid
+            _pos_with_grid_point(
+                _grid_position_name(pos, gp, gp_idx, p_idx, has_plate), pos, gp
+            )
+            for gp_idx, gp in enumerate(global_grid)
             for p_idx, pos in enumerate(seq.stage_positions)
         ]
 
@@ -511,21 +542,10 @@ def _build_stage_positions_plan(seq: useq.MDASequence) -> list[Position]:
 
         if grid:
             for gp_idx, gp in enumerate(grid):
-                # Position naming priority:
-                # 1. Explicit name from user
-                # 2. fov{grid_index} for plate positions (matches WellPlatePlan)
-                # 3. str(position_index) fallback
-                if pos.name:
-                    name = pos.name
-                elif has_plate:
-                    name = f"fov{gp_idx}"
-                else:
-                    name = str(p_idx)
-                positions.append(
-                    _pos_with_grid_point(
-                        name, pos, gp, gp_idx, p_idx if num_pos > 1 else None
-                    )
+                name = _grid_position_name(
+                    pos, gp, gp_idx, p_idx if num_pos > 1 else None, has_plate
                 )
+                positions.append(_pos_with_grid_point(name, pos, gp))
         else:
             plate_row, plate_col = _plate_strs(pos)
             # Same naming priority as above; without a grid each

--- a/src/ome_writers/_useq.py
+++ b/src/ome_writers/_useq.py
@@ -484,6 +484,12 @@ def _build_stage_positions_plan(seq: useq.MDASequence) -> list[Position]:
         and seq.axis_order.index(Axis.GRID) < seq.axis_order.index(Axis.POSITION)
     )
 
+    # Check if positions have plate annotations (plate_row/plate_col)
+    has_plate = any(
+        p.plate_row is not None and p.plate_col is not None
+        for p in seq.stage_positions
+    )
+
     if grid_first and global_grid:
         # Grid-first: outer loop is grid points, inner loop is positions
         return [
@@ -496,8 +502,6 @@ def _build_stage_positions_plan(seq: useq.MDASequence) -> list[Position]:
     positions: list[Position] = []
     num_pos = len(seq.stage_positions)
     for p_idx, pos in enumerate(seq.stage_positions):
-        name = pos.name or str(p_idx)
-
         # Determine which grid to use for this position
         # Priority: subsequence grid > global grid > no grid
         if pos.sequence and pos.sequence.grid_plan:
@@ -507,6 +511,16 @@ def _build_stage_positions_plan(seq: useq.MDASequence) -> list[Position]:
 
         if grid:
             for gp_idx, gp in enumerate(grid):
+                # Position naming priority:
+                # 1. Explicit name from user
+                # 2. fov{grid_index} for plate positions (matches WellPlatePlan)
+                # 3. str(position_index) fallback
+                if pos.name:
+                    name = pos.name
+                elif has_plate:
+                    name = f"fov{gp_idx}"
+                else:
+                    name = str(p_idx)
                 positions.append(
                     _pos_with_grid_point(
                         name, pos, gp, gp_idx, p_idx if num_pos > 1 else None
@@ -514,6 +528,14 @@ def _build_stage_positions_plan(seq: useq.MDASequence) -> list[Position]:
                 )
         else:
             plate_row, plate_col = _plate_strs(pos)
+            # Same naming priority as above; without a grid each
+            # position is a single fov in its well, so always fov0
+            if pos.name:
+                name = pos.name
+            elif has_plate:
+                name = "fov0"
+            else:
+                name = str(p_idx)
             positions.append(
                 Position(
                     name=name,

--- a/src/ome_writers/_useq.py
+++ b/src/ome_writers/_useq.py
@@ -512,18 +512,17 @@ def _build_stage_positions_plan(seq: useq.MDASequence) -> list[Position]:
         and seq.axis_order.index(Axis.GRID) < seq.axis_order.index(Axis.POSITION)
     )
 
+    positions: list[Position] = []
+
     if grid_first and global_grid:
         # Grid-first: outer loop is grid points, inner loop is positions
-        return [
-            _pos_with_grid_point(
-                _grid_position_name(pos, gp, gp_idx, p_idx), pos, gp
-            )
-            for gp_idx, gp in enumerate(global_grid)
-            for p_idx, pos in enumerate(seq.stage_positions)
-        ]
+        for gp_idx, gp in enumerate(global_grid):
+            for p_idx, pos in enumerate(seq.stage_positions):
+                name = _grid_position_name(pos, gp, gp_idx, p_idx)
+                positions.append(_pos_with_grid_point(name, pos, gp))
+        return positions
 
     # Position-first (default)
-    positions: list[Position] = []
     num_pos = len(seq.stage_positions)
     for p_idx, pos in enumerate(seq.stage_positions):
         # Determine which grid to use for this position

--- a/src/ome_writers/_useq.py
+++ b/src/ome_writers/_useq.py
@@ -430,30 +430,49 @@ def _plate_strs(pos: useq.Position) -> tuple[str | None, str | None]:
 
 def _grid_position_name(
     pos: useq.Position,
-    gp: useq.Position,
-    gp_idx: int,
-    pos_idx: int | None,
+    gp: useq.Position | None = None,
+    gp_idx: int = 0,
+    pos_idx: int | None = None,
 ) -> str:
-    """Determine the name for a grid-expanded position.
+    """Determine the storage name for a position.
+
+    Used for both grid-expanded positions and standalone positions. When called
+    without a grid point (gp=None), returns a base name for a single-FOV position.
 
     Naming priority:
-    1. Explicit name from user (may be further suffixed for RandomPoints)
-    2. fov{grid_index} for plate positions (matches WellPlatePlan convention)
-    3. str(position_index) fallback
+      1. Explicit user name — preserved as-is for regular grids, suffixed for
+         RandomPoints (e.g. "mypos" → "mypos_g0000")
+      2. Plate positions (plate_row/plate_col set) — "fov{gp_idx}", matching
+         the WellPlatePlan convention
+      3. Fallback — str(pos_idx), e.g. "0", "1"
 
-    For RandomPoints (no grid_row/grid_col), an index suffix is appended
-    to ensure uniqueness since grid coordinates can't distinguish positions.
+    Parameters
+    ----------
+    pos : useq.Position
+        The original stage position (carries name, plate_row, plate_col).
+    gp : useq.Position | None
+        The grid point being merged. None when there is no grid.
+    gp_idx : int
+        Index of the grid point within the grid (used in fov and suffix naming).
+    pos_idx : int | None
+        Index of the stage position. None when there is only one position,
+        which simplifies RandomPoints suffixes (omits the p{idx} prefix).
     """
+    # 1. Explicit user name
     if pos.name:
         name = pos.name
+    # 2. Plate position → fov naming
     elif pos.plate_row is not None and pos.plate_col is not None:
         return f"fov{gp_idx}"
+    # 3. Fallback to position index
     else:
-        # pos_idx is None when there's only one position (index 0)
         name = str(pos_idx if pos_idx is not None else 0)
 
-    # RandomPoints have no grid_row/grid_col — append index for uniqueness
-    if gp.grid_row is None and gp.grid_col is None:
+    # RandomPoints produce grid points without row/col — append a unique
+    # suffix since the name alone can't distinguish sub-positions.
+    #   Single position:    "name_g0000", "name_g0001"
+    #   Multiple positions: "name_p0000_g0000", "name_p0001_g0000"
+    if gp is not None and gp.grid_row is None and gp.grid_col is None:
         if pos_idx is not None:
             suffix = f"p{pos_idx:04d}_g{gp_idx:04d}"
             return f"{name}_{suffix}" if name else suffix
@@ -540,14 +559,7 @@ def _build_stage_positions_plan(seq: useq.MDASequence) -> list[Position]:
                 positions.append(_pos_with_grid_point(name, pos, gp))
         else:
             plate_row, plate_col = _plate_strs(pos)
-            # Same naming priority as _grid_position_name; without a grid
-            # each position is a single fov in its well, so always fov0
-            if pos.name:
-                name = pos.name
-            elif pos.plate_row is not None and pos.plate_col is not None:
-                name = "fov0"
-            else:
-                name = str(p_idx)
+            name = _grid_position_name(pos, pos_idx=p_idx)
             positions.append(
                 Position(
                     name=name,

--- a/src/ome_writers/_useq.py
+++ b/src/ome_writers/_useq.py
@@ -433,7 +433,6 @@ def _grid_position_name(
     gp: useq.Position,
     gp_idx: int,
     pos_idx: int | None,
-    has_plate: bool,
 ) -> str:
     """Determine the name for a grid-expanded position.
 
@@ -447,7 +446,7 @@ def _grid_position_name(
     """
     if pos.name:
         name = pos.name
-    elif has_plate:
+    elif pos.plate_row is not None and pos.plate_col is not None:
         return f"fov{gp_idx}"
     else:
         # pos_idx is None when there's only one position (index 0)
@@ -513,17 +512,11 @@ def _build_stage_positions_plan(seq: useq.MDASequence) -> list[Position]:
         and seq.axis_order.index(Axis.GRID) < seq.axis_order.index(Axis.POSITION)
     )
 
-    # Check if positions have plate annotations (plate_row/plate_col)
-    has_plate = any(
-        p.plate_row is not None and p.plate_col is not None
-        for p in seq.stage_positions
-    )
-
     if grid_first and global_grid:
         # Grid-first: outer loop is grid points, inner loop is positions
         return [
             _pos_with_grid_point(
-                _grid_position_name(pos, gp, gp_idx, p_idx, has_plate), pos, gp
+                _grid_position_name(pos, gp, gp_idx, p_idx), pos, gp
             )
             for gp_idx, gp in enumerate(global_grid)
             for p_idx, pos in enumerate(seq.stage_positions)
@@ -543,16 +536,16 @@ def _build_stage_positions_plan(seq: useq.MDASequence) -> list[Position]:
         if grid:
             for gp_idx, gp in enumerate(grid):
                 name = _grid_position_name(
-                    pos, gp, gp_idx, p_idx if num_pos > 1 else None, has_plate
+                    pos, gp, gp_idx, p_idx if num_pos > 1 else None
                 )
                 positions.append(_pos_with_grid_point(name, pos, gp))
         else:
             plate_row, plate_col = _plate_strs(pos)
-            # Same naming priority as above; without a grid each
-            # position is a single fov in its well, so always fov0
+            # Same naming priority as _grid_position_name; without a grid
+            # each position is a single fov in its well, so always fov0
             if pos.name:
                 name = pos.name
-            elif has_plate:
+            elif pos.plate_row is not None and pos.plate_col is not None:
                 name = "fov0"
             else:
                 name = str(p_idx)

--- a/tests/test_useq.py
+++ b/tests/test_useq.py
@@ -160,6 +160,69 @@ SEQ_CASES = [
         ],
         id="well_plate_with_points",
     ),
+    # Plate positions (plate_row/plate_col) with global grid, no explicit names.
+    # Names should be fov0..fovN per well, matching WellPlatePlan convention.
+    Case(
+        seq=useq.MDASequence(
+            axis_order="pgtc",
+            stage_positions=[
+                useq.Position(x=0, y=0, plate_row=0, plate_col=0),
+                useq.Position(x=10, y=10, plate_row=0, plate_col=1),
+                useq.Position(x=20, y=20, plate_row=1, plate_col=0),
+            ],
+            grid_plan=useq.GridRowsColumns(rows=1, columns=2),
+            channels=["DAPI"],
+        ),
+        expected_dim_names=["p", "c", "y", "x"],
+        expected_positions=[
+            ExpectedPosition("fov0", "A", "1", grid_row=0, grid_col=0),
+            ExpectedPosition("fov1", "A", "1", grid_row=0, grid_col=1),
+            ExpectedPosition("fov0", "A", "2", grid_row=0, grid_col=0),
+            ExpectedPosition("fov1", "A", "2", grid_row=0, grid_col=1),
+            ExpectedPosition("fov0", "B", "1", grid_row=0, grid_col=0),
+            ExpectedPosition("fov1", "B", "1", grid_row=0, grid_col=1),
+        ],
+        id="plate_positions_with_global_grid",
+    ),
+    # Plate positions without grid, no explicit names.
+    # Each position becomes a single fov in its well.
+    Case(
+        seq=useq.MDASequence(
+            stage_positions=[
+                useq.Position(x=0, y=0, plate_row=0, plate_col=0),
+                useq.Position(x=10, y=10, plate_row=0, plate_col=1),
+                useq.Position(x=20, y=20, plate_row=1, plate_col=0),
+            ],
+            channels=["DAPI"],
+        ),
+        expected_dim_names=["p", "c", "y", "x"],
+        expected_positions=[
+            ExpectedPosition("fov0", "A", "1"),
+            ExpectedPosition("fov0", "A", "2"),
+            ExpectedPosition("fov0", "B", "1"),
+        ],
+        id="plate_positions_no_grid",
+    ),
+    # Plate positions with grid and explicit names — user names preserved.
+    Case(
+        seq=useq.MDASequence(
+            axis_order="pgtc",
+            stage_positions=[
+                useq.Position(x=0, y=0, name="site_a", plate_row=0, plate_col=0),
+                useq.Position(x=10, y=10, name="site_b", plate_row=1, plate_col=0),
+            ],
+            grid_plan=useq.GridRowsColumns(rows=1, columns=2),
+            channels=["DAPI"],
+        ),
+        expected_dim_names=["p", "c", "y", "x"],
+        expected_positions=[
+            ExpectedPosition("site_a", "A", "1", grid_row=0, grid_col=0),
+            ExpectedPosition("site_a", "A", "1", grid_row=0, grid_col=1),
+            ExpectedPosition("site_b", "B", "1", grid_row=0, grid_col=0),
+            ExpectedPosition("site_b", "B", "1", grid_row=0, grid_col=1),
+        ],
+        id="plate_positions_with_explicit_names",
+    ),
     # MultiPhaseTimePlan - no single .interval attribute
     Case(
         seq=useq.MDASequence(


### PR DESCRIPTION
## Summary
- When `stage_positions` have `plate_row`/`plate_col` but no explicit `name`, generate fov-indexed names consistent with `WellPlatePlan` convention
- With grid: each grid sub-position gets `fov0`, `fov1`, ... per well
- Without grid: each position is `fov0` in its well
- Explicit user-provided names are always preserved
- Existing naming conventions for non-plate positions are unchanged (numeric index, RandomPoints suffixes, etc.)
- Refactors naming logic into a dedicated `_grid_position_name` helper; `_pos_with_grid_point` now only handles coordinate merging

Closes #131
Supersedes #135

## What this does NOT change
- Non-plate position naming (`"0"`, `"1"`, etc.)
- RandomPoints naming (`rp_g0000`, `rp_p0000_g0001`, etc.)
- WellPlatePlan naming (`fov0`, `fov1`, etc.)
- All existing tests pass unmodified

## Test plan
- [x] All 681 tests pass (3 new, 678 existing unmodified)
- [x] `plate_positions_with_global_grid` — plate + grid, no names → `fov0`/`fov1` per well
- [x] `plate_positions_no_grid` — plate without grid, no names → `fov0` per well
- [x] `plate_positions_with_explicit_names` — user names preserved
- [x] End-to-end verified with shrimpy CLI (3 plate positions + 3x3 grid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)